### PR TITLE
feat: upgrade package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libomxil-bellagio (0.9.3-8) unstable; urgency=low
+
+  * Fix FTBFS on mipsel. (Closes: #1028978)
+    - add debian/patches/0017_patch_for_strncpy.patch
+
+ -- Ying-Chun Liu (PaulLiu) <paulliu@debian.org>  Mon, 16 Jan 2023 22:35:07 +0800
+
 libomxil-bellagio (0.9.3-7) unstable; urgency=low
 
   * Fix FTBFS with GCC-11. (Closes: #984195)

--- a/debian/patches/0017_patch_for_strncpy.patch
+++ b/debian/patches/0017_patch_for_strncpy.patch
@@ -1,0 +1,22 @@
+From: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>
+Subject: fix FTBFS on mipsel
+ We got /usr/include/mipsel-linux-gnu/bits/string_fortified.h:95:10:
+ error: ‘__builtin_strncpy’ destination unchanged after copying no bes
+ [-Werror=stringop-truncation]
+ Thus we check the size before call strncpy.
+Bug-Debian: http://bugs.debian.org/1028978
+Index: libomxil-bellagio-0.9.3/src/omxregister.c
+===================================================================
+--- libomxil-bellagio-0.9.3.orig/src/omxregister.c
++++ libomxil-bellagio-0.9.3/src/omxregister.c
+@@ -107,7 +107,9 @@ static int showComponentsList(FILE* omxr
+ 		while ((temp_buffer[i] != '\0') && (temp_buffer[i] != ' ')) {
+ 			i++;
+ 		}
+-		strncpy(comp_name, temp_buffer, i);
++		if (i > 0) {
++			strncpy(comp_name, temp_buffer, i);
++		}
+ 		comp_name[i] = '\0';
+ 		temp_buffer += i;
+ 		if (*temp_buffer != '\0') {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@
 0014_fix_hardening.patch
 0015_port_gcc_10.patch
 0016_port_gcc_11.patch
+0017_patch_for_strncpy.patch


### PR DESCRIPTION
fix: `error: '__builtin_strncpy' destination unchanged after copying no bytes`